### PR TITLE
Protect the agent configuration file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,7 @@ optdepends=()
 makedepends=()
 conflicts=()
 replaces=()
-backup=()
+backup=('etc/dataloop/agent.yaml')
 install='dataloop-agent.install'
 source=("https://download.dataloop.io/deb/pool/main/d/dataloop-agent/${pkgname}_${pkgver}-${pkgrel}_amd64.deb"
         "dataloop-agent.service")


### PR DESCRIPTION
Protect the agent.yaml configuration file during updates as it contains user-configured data. Without this the API key and local settings will be wiped, breaking the agent.